### PR TITLE
Use character affiliation endpoint

### DIFF
--- a/app/Controller/Ccp/Sso.php
+++ b/app/Controller/Ccp/Sso.php
@@ -505,25 +505,31 @@ class Sso extends Api\User{
                 $characterData->corporation = null;
                 $characterData->alliance = null;
 
-                if($corporationId = (int)$characterDataBasic['corporation']['id']){
-                    /**
-                     * @var $corporation Pathfinder\CorporationModel
-                     */
-                    $corporation = Pathfinder\AbstractPathfinderModel::getNew('CorporationModel');
-                    $corporation->getById($corporationId, 0);
-                    if($corporation->valid()){
-                        $characterData->corporation = $corporation;
-                    }
-                }
+                $characterAffiliation = $this->getF3()->ccpClient()->send('getCharacterAffiliation', [$characterId]);
+                if(count($characterAffiliation) === 1) {
+                    $characterCorporationId = $characterAffiliation[0]['corporation']['id'];
+                    $characterAllianceId = $characterAffiliation[0]['alliance']['id'];
 
-                if($allianceId = (int)$characterDataBasic['alliance']['id']){
-                    /**
-                     * @var $alliance Pathfinder\AllianceModel
-                     */
-                    $alliance = Pathfinder\AbstractPathfinderModel::getNew('AllianceModel');
-                    $alliance->getById($allianceId, 0);
-                    if($alliance->valid()){
-                        $characterData->alliance = $alliance;
+                    if($corporationId = (int)$characterCorporationId){
+                        /**
+                         * @var $corporation Pathfinder\CorporationModel
+                         */
+                        $corporation = Pathfinder\AbstractPathfinderModel::getNew('CorporationModel');
+                        $corporation->getById($corporationId, 0);
+                        if($corporation->valid()){
+                            $characterData->corporation = $corporation;
+                        }
+                    }
+
+                    if($allianceId = (int)$characterAllianceId){
+                        /**
+                         * @var $alliance Pathfinder\AllianceModel
+                         */
+                        $alliance = Pathfinder\AbstractPathfinderModel::getNew('AllianceModel');
+                        $alliance->getById($allianceId, 0);
+                        if($alliance->valid()){
+                            $characterData->alliance = $alliance;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Update getCharacterData to use the character affiliation endpoint to get Character's corporation & alliance info after CCP increased cache duration to 7 days on public character info endpoint.